### PR TITLE
Update init address list with Dat Penguin Club Contract address

### DIFF
--- a/src/services/hrc721/init.js
+++ b/src/services/hrc721/init.js
@@ -5,12 +5,20 @@ const initArray = {
       address: "0x4abd7C503445380dDc3844DcaE1d08dB997C714A",
       name: "Lma-Art",
     },
+    {
+      address: "0x560cE20C7a7E510b38CfaAd560aF1a4f03C5aEe9",
+      name: "Dat Penguin Club"
+    }
   ],
   Testnet: [
     {
       address: "0x8bb8231048722f6157e56c6d48ff957a094233ad",
       name: "BeastQuest",
     },
+    {
+      address: "0x3578f29a70F28ABCc90Cc31645823d0A68F704e7",
+      name: "Dat Penguin Club"
+    }
   ],
   Localnet: [],
 };


### PR DESCRIPTION
Dat Penguin Club is an upcoming NFT Collection on Harmony One. The minting Dapp https://datpenguinclub.com only supports Harmony One Chrome Wallet Extension. To ensure a seamless user experience during the initial minting Dapp - adding the contract address to `init.js` will instantly help users to view their NFTs.